### PR TITLE
Hide navigation title in MapViewController to avoid affecting tab bar item title

### DIFF
--- a/iphone/Maps/Classes/MapViewController.mm
+++ b/iphone/Maps/Classes/MapViewController.mm
@@ -317,7 +317,8 @@ NSString *const kPP2BookmarkEditingSegue = @"PP2BookmarkEditing";
 - (void)viewDidLoad {
   [super viewDidLoad];
 
-  self.title = L(@"map");
+// Update the title will change both the navigation title and the tab bar item title simultaneously
+//  self.title = L(@"map");
 
   // On iOS 10 (it was reproduced, it may be also on others), mapView can be uninitialized
   // when onGetFocus is called, it can lead to missing of onGetFocus call and a deadlock on the start.


### PR DESCRIPTION
Asana link: https://app.asana.com/0/1155243396167385/1207783203223743/f
## What is the new behavior
- Hide navigation title in MapViewController to avoid affecting tab bar item title